### PR TITLE
Change Type name  KnownFolder to O365KnownFolder

### DIFF
--- a/ConnectO365/InstallModules.psm1
+++ b/ConnectO365/InstallModules.psm1
@@ -92,7 +92,7 @@ Add-Type @"
     using System;
     using System.Runtime.InteropServices;
 
-    public static class KnownFolder
+    public static class O365KnownFolder
     {
         public static readonly Guid Documents = new Guid( "FDD39AD0-238F-46AF-ADB4-6C85480369C7" );
         public static readonly Guid Downloads = new Guid( "374DE290-123F-4565-9164-39C4925E467B" );


### PR DESCRIPTION
I was getting an error with the type name for KnownFolder in InstallModules.psm1. Changed the type name to O365KnownFolder and it goes through fine now.

http://pastebin.com/USiQEpRH